### PR TITLE
fix: electron auto updater does not work for mac

### DIFF
--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -1,10 +1,9 @@
 const aliases = {
-  darwin: ['mac', 'macos', 'osx'],
   exe: ['win32', 'windows', 'win'],
   deb: ['debian'],
   rpm: ['fedora'],
   AppImage: ['appimage'],
-  dmg: ['dmg']
+  dmg: ['dmg', 'darwin', 'mac', 'macos', 'osx']
 }
 
 for (const existingPlatform of Object.keys(aliases)) {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -9,7 +9,7 @@ module.exports = fileName => {
     (fileName.includes('mac') || fileName.includes('darwin')) &&
     extension === 'zip'
   ) {
-    return 'darwin' + arch
+    return 'dmg' + arch
   }
 
   const directCache = ['exe', 'dmg', 'rpm', 'deb', 'AppImage']

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -38,14 +38,10 @@ module.exports = ({ cache, config }) => {
 
   exports.download = async (req, res) => {
     const userAgent = parse(req.headers['user-agent'])
-    const params = new urlHelpers.URL(req.url, config.url).searchParams
-    const isUpdate = params.get('update')
 
     let platform
 
-    if (userAgent.isMac && isUpdate) {
-      platform = 'darwin'
-    } else if (userAgent.isMac && !isUpdate) {
+    if (userAgent.isMac) {
       platform = 'dmg'
     } else if (userAgent.isWindows) {
       platform = 'exe'

--- a/test/aliases.test.js
+++ b/test/aliases.test.js
@@ -4,12 +4,12 @@ const aliases = require('../lib/aliases')
 describe('Aliases', () => {
   it('Should return the correct platform', () => {
     const result = aliases('mac')
-    expect(result).toBe('darwin')
+    expect(result).toBe('dmg')
   })
 
   it('Should return the platform when the platform is provided', () => {
-    const result = aliases('darwin')
-    expect(result).toBe('darwin')
+    const result = aliases('dmg')
+    expect(result).toBe('dmg')
   })
 
   it('Should return false if no platform is found', () => {

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -62,6 +62,6 @@ describe('Cache', function () {
     const cache = new Cache(config)
     const storage = await cache.loadCache()
 
-    console.log(storage.platforms.darwin)
+    console.log(storage.platforms.dmg)
   })
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -3,7 +3,7 @@
 const Cache = require('../lib/cache')
 
 describe('Cache', function () {
-  this.timeout = 30000
+  this.timeout = 15000
   it('should throw when account is not defined', () => {
     expect(() => {
       const config = { repository: 'hyper' }

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -3,7 +3,6 @@
 const Cache = require('../lib/cache')
 
 describe('Cache', function () {
-  this.timeout = 10000
   it('should throw when account is not defined', () => {
     expect(() => {
       const config = { repository: 'hyper' }
@@ -51,7 +50,7 @@ describe('Cache', function () {
 
     expect(typeof storage.version).toBe('string')
     expect(typeof storage.platforms).toBe('object')
-  })
+  }, 30000)
 
   it('should set platforms correctly', async () => {
     const config = {

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -36,8 +36,6 @@ describe('Cache', function () {
   })
 
   it('should refresh the cache', async () => {
-    jest.setTimeout(30000);
-
     const config = {
       account: 'zeit',
       repository: 'hyper',

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -3,6 +3,7 @@
 const Cache = require('../lib/cache')
 
 describe('Cache', function () {
+  this.timeout = 30000
   it('should throw when account is not defined', () => {
     expect(() => {
       const config = { repository: 'hyper' }
@@ -48,7 +49,7 @@ describe('Cache', function () {
 
     expect(typeof storage.version).toBe('string')
     expect(typeof storage.platforms).toBe('object')
-  }, 30000)
+  })
 
   it('should set platforms correctly', async () => {
     const config = {

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -3,7 +3,7 @@
 const Cache = require('../lib/cache')
 
 describe('Cache', function () {
-  this.timeout = 15000
+  this.timeout = 10000
   it('should throw when account is not defined', () => {
     expect(() => {
       const config = { repository: 'hyper' }

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -37,6 +37,8 @@ describe('Cache', function () {
   })
 
   it('should refresh the cache', async () => {
+    jest.setTimeout(30000);
+
     const config = {
       account: 'zeit',
       repository: 'hyper',

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -4,7 +4,7 @@ const platform = require('../lib/platform')
 describe('Platform', () => {
   it('Should parse mac', () => {
     const result = platform('hyper-2.1.1-mac.zip')
-    expect(result).toBe('darwin')
+    expect(result).toBe('dmg')
   })
 
   it('Should parse other platforms', () => {


### PR DESCRIPTION
when a request is sent to the auto updating service for mac users, it responds with a link to the windows installer instead